### PR TITLE
fix: Add missing signInWithOAuth method to mock Supabase client

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -81,20 +81,30 @@ try {
       getSession: () => Promise.resolve({ data: { session: null }, error: null }),
       getUser: () => Promise.resolve({ data: { user: null }, error: null }),
       signOut: () => Promise.resolve({ error: null }),
+      signInWithOAuth: () => Promise.resolve({
+        data: { provider: null, url: null },
+        error: new Error('Supabase client not initialized. Please check environment variables.')
+      }),
       onAuthStateChange: () => ({
         data: { subscription: { unsubscribe: () => {} } },
         unsubscribe: () => {}
       })
     },
     from: () => ({
-      select: () => ({ 
+      select: () => ({
         single: () => Promise.resolve({ data: null, error: null }),
         eq: () => ({ single: () => Promise.resolve({ data: null, error: null }) })
       }),
       insert: () => Promise.resolve({ data: null, error: null }),
       update: () => Promise.resolve({ data: null, error: null }),
       delete: () => Promise.resolve({ data: null, error: null })
-    })
+    }),
+    functions: {
+      invoke: () => Promise.resolve({
+        data: null,
+        error: new Error('Supabase client not initialized. Please check environment variables.')
+      })
+    }
   };
 }
 


### PR DESCRIPTION
- Added signInWithOAuth to mock auth object to prevent 'not a function' errors
- Added functions.invoke to mock client for completeness
- Both methods return appropriate error messages when client is not initialized
- Prevents app crashes when VITE_SUPABASE_* environment variables are missing